### PR TITLE
fix: 🐛 remove the nth child background css

### DIFF
--- a/wp-template/style.css
+++ b/wp-template/style.css
@@ -2856,7 +2856,6 @@ div.credits {
  .m0 table {
   margin-top:0; 
   margin-bottom:0;
-  :nth-child(odd) {background-color: #bae8ff;}
 }
 .m0 tbody {
   border-width:0;


### PR DESCRIPTION
<img width="350" src="https://media.giphy.com/media/if8YsCNzoXBjT0Vx3J/giphy.gif">

### Changes

- Remove the nth child css backgound property

### Validate

- Check the character page when previewing the test theme

